### PR TITLE
Bump Phoenix and Node versions to latest stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,12 +23,14 @@ RUN apt-get install -y erlang erlang-ssl erlang-inets && rm erlang-solutions_1.0
 RUN git clone https://github.com/elixir-lang/elixir.git && cd elixir && git checkout v1.0.5 && make
 ENV PATH $PATH:/elixir/bin
 
+ENV PHOENIX_VERSION 0.16.1
+
 # install Phoenix from source with some previous requirements
 RUN git clone https://github.com/phoenixframework/phoenix.git \
- && cd phoenix && git checkout v0.15.0 \
+ && cd phoenix && git checkout v$PHOENIX_VERSION \
  && mix local.hex --force && mix local.rebar --force \
  && mix do deps.get, compile \
- && mix archive.install https://github.com/phoenixframework/phoenix/releases/download/v0.15.0/phoenix_new-0.15.0.ez --force
+ && mix archive.install https://github.com/phoenixframework/phoenix/releases/download/v$PHOENIX_VERSION/phoenix_new-$PHOENIX_VERSION.ez --force
 
 # install Node.js and NPM in order to satisfy brunch.io dependencies
 # the snippet below is borrowed from the official nodejs Dockerfile
@@ -39,7 +41,7 @@ RUN git clone https://github.com/phoenixframework/phoenix.git \
 # gpg: aka "Julien Gilli <jgilli@fastmail.fm>"
 RUN gpg --keyserver pool.sks-keyservers.net --recv-keys 7937DFD2AB06298B2293C3187D33FF9D0246406D 114F43EE0176B71C7BC219DD50A3051F888C628D
 
-ENV NODE_VERSION 0.12.5
+ENV NODE_VERSION 0.12.7
 ENV NPM_VERSION 2.12.0
 
 RUN curl -SLO "http://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \


### PR DESCRIPTION
This tiny change just bumps the versions. Also I added an env var for the Phoenix version to avoid repeating it. Thanks for the Dockerfile!
