### PR TITLE
Updated version for Elixir and Phoenix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,12 @@ RUN wget http://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb \
 # install erlang from package
 RUN apt-get install -y erlang erlang-ssl erlang-inets && rm erlang-solutions_1.0_all.deb
 
+ENV ELIXIR_VERSION 1.1.0
 # install elixir from source
-RUN git clone https://github.com/elixir-lang/elixir.git && cd elixir && git checkout v1.0.5 && make
+RUN git clone https://github.com/elixir-lang/elixir.git && cd elixir && git checkout v$ELIXIR_VERSION && make
 ENV PATH $PATH:/elixir/bin
 
-ENV PHOENIX_VERSION 1.0.0
+ENV PHOENIX_VERSION 1.1.2
 
 # install Phoenix from source with some previous requirements
 RUN git clone https://github.com/phoenixframework/phoenix.git \


### PR DESCRIPTION
Made the Phoenix version an environment variable in preparation
for opening these up as environment variables for image creators.

Updated the Phoenix version to the latest version.

The main reason for this is because the latest Phoenix tutorials
would not work without an up to date image that includes latest Elixir 
and Phoenix versions.
