### PR TITLE
Add --force option for mix archive.install task

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get install -y elixir && rm erlang-solutions_1.0_all.deb
 ENV PHOENIX_VERSION 1.1.4
 
 # install the Phoenix Mix archive
-RUN mix archive.install https://github.com/phoenixframework/archives/raw/master/phoenix_new-$PHOENIX_VERSION.ez
+RUN mix archive.install --force https://github.com/phoenixframework/archives/raw/master/phoenix_new-$PHOENIX_VERSION.ez
 
 # install Node.js (>= 5.0.0) and NPM in order to satisfy brunch.io dependencies
 # See http://www.phoenixframework.org/docs/installation#section-node-js-5-0-0-


### PR DESCRIPTION
I had an issue with your Dockerfile - `mix archive.install ...` is asking for permission to install an archive. I added --force option to fix this.
