### PR TITLE
Install mix and rebar locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ ENV PHOENIX_VERSION 1.2.1
 
 # install the Phoenix Mix archive
 RUN mix archive.install --force https://github.com/phoenixframework/archives/raw/master/phoenix_new-$PHOENIX_VERSION.ez
+RUN mix local.hex --force \
+    && mix local.rebar --force
 
 # install Node.js (>= 6.0.0) and NPM in order to satisfy brunch.io dependencies
 # See http://www.phoenixframework.org/docs/installation#section-node-js-5-0-0-


### PR DESCRIPTION
This prevents being asked to install hex and rebar each time a container is created.